### PR TITLE
draft: rough draft of AirdropNFT and LobsNFT

### DIFF
--- a/contracts/AirdropNFT.sol
+++ b/contracts/AirdropNFT.sol
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity =0.8.6;
+
+import "@openzeppelin/contracts/utils/cryptography/MerkleProof.sol";
+import "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
+
+interface ILobsNFT {
+    function mint(address to) external returns(bool);
+}
+
+contract AirdropNFT {
+    address public nft;
+    bytes32 public merkleRoot;
+    address public ivan;
+
+    event Claimed(uint256 index, address account);
+
+    mapping(uint256 => uint256) private claimedBitMap;
+
+    constructor(address nft_, bytes32 merkleRoot_, address ivan_) public {
+        nft = nft_;
+        merkleRoot = merkleRoot_;
+        ivan = ivan_;
+    }
+
+    function isClaimed(uint256 index) public view returns (bool) {
+        uint256 claimedWordIndex = index / 256;
+        uint256 claimedBitIndex = index % 256;
+        uint256 claimedWord = claimedBitMap[claimedWordIndex];
+        uint256 mask = (1 << claimedBitIndex);
+        return claimedWord & mask == mask;
+    }
+
+    function _setClaimed(uint256 index) private {
+        uint256 claimedWordIndex = index / 256;
+        uint256 claimedBitIndex = index % 256;
+        claimedBitMap[claimedWordIndex] = claimedBitMap[claimedWordIndex] | (1 << claimedBitIndex);
+    }
+
+    // a user must provide a merkle proof and an ivan signauture associating them with a recipient address
+    function claim(
+        uint256 index, bytes32[] calldata merkleProof,
+        address account, bytes calldata ivanSignature
+    ) external {
+        require(!isClaimed(index), 'already claimed');
+
+        bytes32 node = keccak256(abi.encodePacked(index));
+        require(MerkleProof.verify(merkleProof, merkleRoot, node), 'invalid merkle proof');
+
+        bytes32 digest = ECDSA.toEthSignedMessageHash(keccak256(abi.encodePacked(index, account)));
+        require(ECDSA.recover(digest, ivanSignature) == ivan, 'invalid ivan signature');
+
+        _setClaimed(index);
+        require(ILobsNFT(nft).mint(account), 'mint failed');
+
+        emit Claimed(index, account);
+    }
+}

--- a/contracts/LobsNFT.sol
+++ b/contracts/LobsNFT.sol
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: MIT
+// permit implementation taken from Amxx: https://github.com/Amxx/Permit/blob/master/contracts/EIP712WithNonce.sol
+pragma solidity ^0.8.6;
+
+import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
+import "@openzeppelin/contracts/utils/cryptography/SignatureChecker.sol";
+import "@openzeppelin/contracts/utils/Counters.sol";
+import "./utils/EIP712WithNonce.sol";
+
+contract LobsNFT is ERC721, Ownable, EIP712WithNonce {
+  using Counters for Counters.Counter;
+
+  bytes32 private immutable _PERMIT721_TYPEHASH = keccak256("Permit721(address registry,uint256 tokenid,address to,uint256 nonce,uint256 deadline,address relayer)");
+  Counters.Counter private _tokenId;
+  address private airdropContract;
+  string private baseUri_;
+
+  event AirdropContractSet(address indexed contractAddress);
+  event BaseURISet(string indexed uri);
+
+  modifier onlyAirdrop() {
+    require(msg.sender == airdropContract || msg.sender == owner()
+      , "only airdrop & owner can mint");
+    _;
+  }
+
+  constructor() 
+    EIP712("LobsterDAO NFT", "1") 
+    ERC721("LobsterDAO NFT", "LOBS") {}
+
+  function getAirdropAddress() external returns(address) {
+    return airdropContract;
+  }
+
+  function setBaseUri(string memory _uri) external onlyOwner {
+    baseUri_ = _uri;
+    emit BaseURISet(_uri);
+  }
+
+  function setAirdrop(address _airdropContract) external onlyOwner {
+    airdropContract = _airdropContract;
+    emit AirdropContractSet(_airdropContract);
+  }
+
+  function mint(address to) onlyAirdrop external returns(bool) {
+    _tokenId.increment();
+    uint256 currentId = _tokenId.current();
+    _safeMint(to, currentId);
+
+    return true;
+  }
+
+  function transfer721WithSign(
+      uint256 tokenId,
+      address to,
+      uint256 nonce,
+      uint256 deadline,
+      bytes memory signature
+  )
+      external
+  {
+      address from = ownerOf(tokenId);
+
+      require(block.timestamp <= deadline, "NFTPermit::transfer721WithSign: Expired deadline");
+      _verifyAndConsumeNonce(from, nonce);
+      require(
+          SignatureChecker.isValidSignatureNow(
+              from,
+              _hashTypedDataV4(keccak256(abi.encode(
+                  _PERMIT721_TYPEHASH,
+                  address(this),
+                  tokenId,
+                  to,
+                  nonce,
+                  deadline
+              ))),
+              signature
+          ),
+          "NFTPermit::transfer721WithSign: Invalid signature"
+      );
+
+      safeTransferFrom(from, to, tokenId);
+  }
+
+  function _baseURI() internal override view returns(string memory) {
+    return baseUri_;
+  }
+}

--- a/contracts/utils/EIP712WithNonce.sol
+++ b/contracts/utils/EIP712WithNonce.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: MIT
+// taken from Amxx: https://github.com/Amxx/Permit/blob/master/contracts/EIP712WithNonce.sol
+
+pragma solidity ^0.8.6;
+
+import "@openzeppelin/contracts/utils/cryptography/draft-EIP712.sol";
+
+abstract contract EIP712WithNonce is EIP712 {
+    mapping(address => mapping(uint256 => uint256)) private _nonces;
+
+    function DOMAIN_SEPARATOR() external view returns (bytes32) {
+        return _domainSeparatorV4();
+    }
+
+    function nonce(address from) public view virtual returns (uint256) {
+        return uint256(_nonces[from][0]);
+    }
+
+    function nonce(address from, uint256 timeline) public view virtual returns (uint256) {
+        return _nonces[from][timeline];
+    }
+
+    function _verifyAndConsumeNonce(address owner, uint256 idx) internal virtual {
+        require(idx % (1 << 128) == _nonces[owner][idx >> 128]++, "invalid-nonce");
+    }
+}


### PR DESCRIPTION
This is some initial thoughts on what the airdrop and NFT contracts might look like based on previous design and some other considerations. I've marked it "draft" since it's just some rough code I threw together as of right now.

**Basic Structure:** The NFT contract must be deployed before the AirdropNFT contract since the latter takes the former's address as an arg. The AirdropNFT contract should allow an airdropped Lobster to mint an NFT. Owners are also able to mint NFTs.

The contract follows a URI structure where `tokenURI` returns the `baseURI` + `tokenId`. As such, metadata should be set with a base IPFS directory in which each metadata JSON matches a `tokenId` - in other words, the metadata should be in JSONs named `1.json`, `2.json`, etc. This way when the NFTs are going to be revealed, the owner can call `setBaseUri` and point the base URI to the directory with all the JSONs, and nothing else will need to be set.

`tokenId`s auto-increment using an OZ counter, there is no need to pass in `tokenId`s to mint.

There is an implementation of `permit` based on Amxx's singleton implementation for approval-less transfers. This is my first time playing around with this, so caution is advised.